### PR TITLE
DUP-74: Properly clean up last node

### DIFF
--- a/js/plugin.js
+++ b/js/plugin.js
@@ -34,15 +34,10 @@
             // convert virtual DOM to CKEDITOR.dom.document and get first and last nodes
             var ckeDocument = new CKEDITOR.dom.document(doc);
             var startNode = ckeDocument.getBody().getChild(0),
-              endNode = ckeDocument.getBody().getChild(ckeDocument.getBody().getChildren().count() - 1),
               currentNode = startNode;
 
             // Loop through all nodes which are dom elements
             while (currentNode && currentNode.type == CKEDITOR.NODE_ELEMENT) {
-              // If we have reached the end of the selection, stop looping.
-              if (currentNode.equals(endNode)) {
-                break;
-              }
 
               var nextNode = currentNode.getNextSourceNode(false, CKEDITOR.NODE_ELEMENT),
                 isFakeElement = currentNode.hasOwnProperty('getName') && currentNode.getName() == 'img' && currentNode.data('cke-realelement');


### PR DESCRIPTION
## Issue
During Ckeditor5 Uprgade preparation, I realized the last node of the copied html body is not processed by the cleaner.

## Fix
Remove the break, as while loop will stop as soon as the nextnode is null